### PR TITLE
Ignore tofu "VRCFlowManagerVRC"

### DIFF
--- a/vrc_auto_rejoin_tool.go
+++ b/vrc_auto_rejoin_tool.go
@@ -24,7 +24,7 @@ import (
 	"time"
 )
 
-const WorldLogPrefix = "[VRCFlowManagerVRC] Destination set: wrld_"
+const WorldLogIdentifier = "] Destination set: wrld_"
 const Location = "Local"
 const TimeFormat = "2006.01.02 15:04:05"
 const vrcRelativeLogPath = `\AppData\LocalLow\VRChat\VRChat\`
@@ -310,7 +310,7 @@ func (v *VRCAutoRejoinTool) parseLatestInstance(s string) (Instance, error) {
 			line = line[:len(line)-1]
 		}
 
-		if !strings.Contains(line, WorldLogPrefix) {
+		if !strings.Contains(line, WorldLogIdentifier) {
 			continue
 
 		}
@@ -461,7 +461,7 @@ func (v *VRCAutoRejoinTool) moved(at time.Time, l string) (Instance, error) {
 		return Instance{}, ErrNotMoved
 	}
 
-	if !strings.Contains(l, WorldLogPrefix) {
+	if !strings.Contains(l, WorldLogIdentifier) {
 		return Instance{}, ErrNotMoved
 	}
 


### PR DESCRIPTION
VRChat build 1046よりログ形式が変わり、VRCFlowManagerVRCだった文字列が美しい記号に変更され検出できなくなった。

Before:
```
2021.02.01 17:34:19 Log        -  [VRCFlowManagerVRC] Destination set: wrld_736bad27-4663-4346-a345-26e1e859d94e:44303
```

After:
```
2021.02.04 14:08:59 Log        -  
[ǄǄǅǅǅǄǄǅǅǄǅǅǅǅǄǄǄǅǅǄǄǅǅǅǅǄǅǅǅǅǄǄǄǄǄǅǄǅǄǄǄǅǅǄǅǅǅ] Destination set: wrld_736bad27-4663-4346-a345-26e1e859d94e:44303
```

![image](https://user-images.githubusercontent.com/11992915/106848736-e120ab00-66f4-11eb-8856-068d06d2a935.png)

@sk2sat 氏による https://github.com/yanorei32/VRChatRejoinTool/pull/4 を参考に、修正。